### PR TITLE
Handle socket read timeouts in sniff mode

### DIFF
--- a/canb0t.py
+++ b/canb0t.py
@@ -132,7 +132,10 @@ def sniff_mode(sock: socket.socket, writer: csv.writer) -> int:
         while True:
             try:
                 line = f.readline()
-            except socket.timeout:
+            except (socket.timeout, OSError) as err:
+                # socket.makefile() may raise OSError("cannot read from timed out object")
+                if isinstance(err, OSError) and err.errno not in (None, 0):
+                    raise
                 if frame_count == 0 and not waiting_notice:
                     console.print("[yellow]No traffic detected yet — waiting…[/]")
                     waiting_notice = True


### PR DESCRIPTION
## Summary
- Prevent link failure when sniffing with no CAN traffic by catching `OSError` timeouts from `socket.makefile()`

## Testing
- `python -m py_compile canb0t.py`
- `pip install rich python-dotenv` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python canb0t.py --help` *(fails: ModuleNotFoundError: No module named 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_68a0b0826420832dbc1f1c17d202eb16