### PR TITLE
Add SparkFun RedBoard CAN-Bus sketch

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,12 @@ python canb0t.py --mode pid --outfile pid_data.csv
 ```
 
 Captured frames are written to the CSV file and debug messages go to the log file, assisting with OBD-II connection troubleshooting.
+
+## SparkFun RedBoard with CAN-Bus Shield
+
+An Arduino sketch (`canb0t_redboard.ino`) is included for running canb0t on a SparkFun RedBoard paired with the [SparkFun CAN-Bus Shield](https://www.sparkfun.com/products/13262). The sketch uses the MCP2515 controller to sniff raw frames or query a few common OBD-II PIDs.
+
+1. Install the [MCP_CAN library](https://github.com/coryjfowler/MCP_CAN_lib) in the Arduino IDE.
+2. Open `canb0t_redboard.ino`.
+3. Set `PID_MODE` to `true` to enable PID polling; otherwise, the sketch logs all observed frames.
+4. Upload to the board and open the serial monitor at 115200 baud to view the log.

--- a/canb0t_redboard.ino
+++ b/canb0t_redboard.ino
@@ -1,0 +1,104 @@
+#include <SPI.h>
+#include <mcp_can.h>
+
+// Change to true to enable OBD-II PID polling mode
+const bool PID_MODE = false; // false = sniff mode, true = PID mode
+
+// MCP2515 CS pin on SparkFun CAN-Bus Shield
+const int CAN_CS = 10;
+MCP_CAN CAN0(CAN_CS);
+
+// Buffer for incoming frames
+unsigned long canId;
+byte len;
+byte buf[8];
+
+// OBD-II PID commands (service 01)
+const unsigned char PID_RPM[8]      = {0x02, 0x01, 0x0C, 0, 0, 0, 0, 0};
+const unsigned char PID_SPEED[8]    = {0x02, 0x01, 0x0D, 0, 0, 0, 0, 0};
+const unsigned char PID_THROTTLE[8] = {0x02, 0x01, 0x11, 0, 0, 0, 0, 0};
+const unsigned char PID_COOLANT[8]  = {0x02, 0x01, 0x05, 0, 0, 0, 0, 0};
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) {
+    ; // wait for serial port to connect. Needed for native USB
+  }
+
+  Serial.println(F("canb0t :: SparkFun RedBoard CAN logger"));
+
+  if (CAN0.begin(MCP_STDEXT, CAN_500KBPS, MCP_8MHZ) == CAN_OK) {
+    Serial.println(F("CAN init ok"));
+  } else {
+    Serial.println(F("CAN init failed"));
+    while (1) {
+      delay(1000);
+    }
+  }
+
+  CAN0.setMode(MCP_NORMAL);
+}
+
+void loop() {
+  if (PID_MODE) {
+    pollPids();
+  } else {
+    sniff();
+  }
+}
+
+void sniff() {
+  if (CAN0.checkReceive() == CAN_MSGAVAIL) {
+    CAN0.readMsgBuf(&len, buf);
+    canId = CAN0.getCanId();
+
+    Serial.print(F("ID: 0x"));
+    Serial.print(canId, HEX);
+    Serial.print(F(" DLC:"));
+    Serial.print(len);
+    Serial.print(F(" Data:"));
+    for (int i = 0; i < len; i++) {
+      Serial.print(' ');
+      if (buf[i] < 0x10) Serial.print('0');
+      Serial.print(buf[i], HEX);
+    }
+    Serial.println();
+  }
+}
+
+void pollPids() {
+  sendPid(PID_RPM);
+  delay(100);
+  sendPid(PID_SPEED);
+  delay(100);
+  sendPid(PID_THROTTLE);
+  delay(100);
+  sendPid(PID_COOLANT);
+  delay(1000); // wait before repeating sequence
+}
+
+void sendPid(const unsigned char *data) {
+  // Standard OBD-II request ID
+  const unsigned long reqId = 0x7DF;
+
+  if (CAN0.sendMsgBuf(reqId, 0, 8, data) == CAN_OK) {
+    if (CAN0.checkReceive() == CAN_MSGAVAIL) {
+      CAN0.readMsgBuf(&len, buf);
+      canId = CAN0.getCanId();
+
+      Serial.print(F("RESP 0x"));
+      Serial.print(canId, HEX);
+      Serial.print(F(":"));
+      for (int i = 0; i < len; i++) {
+        Serial.print(' ');
+        if (buf[i] < 0x10) Serial.print('0');
+        Serial.print(buf[i], HEX);
+      }
+      Serial.println();
+    } else {
+      Serial.println(F("No response"));
+    }
+  } else {
+    Serial.println(F("PID send failed"));
+  }
+}


### PR DESCRIPTION
## Summary
- add `canb0t_redboard.ino` for SparkFun RedBoard and MCP2515-based CAN-Bus Shield
- document Arduino setup and usage

## Testing
- `python -m py_compile canb0t.py`
- `arduino-cli version` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a10ee71920832db9163ea955edc142