### PR TITLE
Log CAN bus data to SD card on RedBoard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,26 @@
 # canb0t
 
-canb0t is a retro-styled CAN bus logger for ELM327-compatible OBD-II adapters. It can sniff raw CAN traffic or poll a set of common PIDs, storing results in a CSV file with a flashy hacker console.
+Arduino sketch for logging CAN bus traffic on a SparkFun RedBoard with the SparkFun CAN-Bus Shield. The sketch writes all CAN frames and basic OBD-II PID responses to a microSD card.
 
 ## Features
-- Initializes an ELM327 adapter and logs every command and response to a debug file
-- **Sniff mode** captures raw CAN frames with a live dashboard showing frame count, unique IDs, and capture rate
-- **PID mode** queries selected PIDs like RPM, speed, throttle, and coolant temperature
-- Saves all frames with timestamps to a CSV output file
-- Rich-based neon console with random one-liners for style
-
-## Installation
-1. Ensure Python 3.11+ is installed
-2. Install dependencies:
-   ```bash
-   pip install rich python-dotenv
-   ```
-3. Optionally create a virtual environment before installing
+- Initializes the MCP2515 CAN controller and SD card
+- Optional PID polling for RPM, speed, throttle and coolant temperature
+- Logs every frame with timestamp to `canlog.csv` on the shield's microSD card
+- Mirrors frames over the serial port at 115200 baud
 
 ## Setup
-- The script reads configuration from environment variables or command-line flags. Place values in a `.env` file or export them before running.
-  - `IP` – adapter IP address (default `192.168.0.10`)
-  - `PORT` – adapter TCP port (default `35000`)
-  - `OUTFILE` – CSV output file (default `can_log.csv`)
-  - `LOGFILE` – debug log file (default `canb0t.log`)
-  - `MODE` – `sniff` or `pid` (default `sniff`)
+1. Install the [MCP_CAN library](https://github.com/coryjfowler/MCP_CAN_lib) and the built-in SD library in the Arduino IDE.
+2. Assemble the SparkFun CAN-Bus Shield on the RedBoard and insert a microSD card.
+3. Open `canb0t_redboard.ino` in the Arduino IDE.
+4. Set `PID_MODE` to `true` to enable PID polling or `false` to sniff raw frames.
+5. Upload to the board and open the serial monitor at 115200 baud to view live output.
 
-## Usage
-Show help:
-```bash
-python canb0t.py --help
+## SD Logging
+When running, the sketch creates `canlog.csv` on the microSD card with lines formatted as:
+
+```
+timestamp_ms,id,dlc,data
+1234,1AB,8,00 FF AA BB CC DD EE FF
 ```
 
-Sniff raw frames and log debug output:
-```bash
-python canb0t.py --ip 192.168.0.10 --port 35000 --mode sniff --logfile debug.log
-```
-
-Poll for PID data:
-```bash
-python canb0t.py --mode pid --outfile pid_data.csv
-```
-
-Captured frames are written to the CSV file and debug messages go to the log file, assisting with OBD-II connection troubleshooting.
-
-## SparkFun RedBoard with CAN-Bus Shield
-
-An Arduino sketch (`canb0t_redboard.ino`) is included for running canb0t on a SparkFun RedBoard paired with the [SparkFun CAN-Bus Shield](https://www.sparkfun.com/products/13262). The sketch uses the MCP2515 controller to sniff raw frames or query a few common OBD-II PIDs.
-
-1. Install the [MCP_CAN library](https://github.com/coryjfowler/MCP_CAN_lib) in the Arduino IDE.
-2. Open `canb0t_redboard.ino`.
-3. Set `PID_MODE` to `true` to enable PID polling; otherwise, the sketch logs all observed frames.
-4. Upload to the board and open the serial monitor at 115200 baud to view the log.
+Each line contains the millisecond timestamp, CAN identifier, data length code, and hex data bytes.

--- a/canb0t_redboard.ino
+++ b/canb0t_redboard.ino
@@ -1,12 +1,16 @@
+// CAN logging sketch for SparkFun RedBoard + CAN-Bus Shield
 #include <SPI.h>
+#include <SD.h>
 #include <mcp_can.h>
 
 // Change to true to enable OBD-II PID polling mode
 const bool PID_MODE = false; // false = sniff mode, true = PID mode
 
-// MCP2515 CS pin on SparkFun CAN-Bus Shield
+// MCP2515 and SD card CS pins on SparkFun CAN-Bus Shield
 const int CAN_CS = 10;
+const int SD_CS  = 9;
 MCP_CAN CAN0(CAN_CS);
+File logFile;
 
 // Buffer for incoming frames
 unsigned long canId;
@@ -26,6 +30,22 @@ void setup() {
   }
 
   Serial.println(F("canb0t :: SparkFun RedBoard CAN logger"));
+
+  if (!SD.begin(SD_CS)) {
+    Serial.println(F("SD init failed"));
+    while (1) {
+      delay(1000);
+    }
+  }
+
+  logFile = SD.open("canlog.csv", FILE_WRITE);
+  if (!logFile) {
+    Serial.println(F("Log file open failed"));
+    while (1) {
+      delay(1000);
+    }
+  }
+  logFile.println(F("timestamp_ms,id,dlc,data"));
 
   if (CAN0.begin(MCP_STDEXT, CAN_500KBPS, MCP_8MHZ) == CAN_OK) {
     Serial.println(F("CAN init ok"));
@@ -51,18 +71,7 @@ void sniff() {
   if (CAN0.checkReceive() == CAN_MSGAVAIL) {
     CAN0.readMsgBuf(&len, buf);
     canId = CAN0.getCanId();
-
-    Serial.print(F("ID: 0x"));
-    Serial.print(canId, HEX);
-    Serial.print(F(" DLC:"));
-    Serial.print(len);
-    Serial.print(F(" Data:"));
-    for (int i = 0; i < len; i++) {
-      Serial.print(' ');
-      if (buf[i] < 0x10) Serial.print('0');
-      Serial.print(buf[i], HEX);
-    }
-    Serial.println();
+    logFrame(canId, len, buf);
   }
 }
 
@@ -82,23 +91,44 @@ void sendPid(const unsigned char *data) {
   const unsigned long reqId = 0x7DF;
 
   if (CAN0.sendMsgBuf(reqId, 0, 8, data) == CAN_OK) {
+    logFrame(reqId, 8, data);
     if (CAN0.checkReceive() == CAN_MSGAVAIL) {
       CAN0.readMsgBuf(&len, buf);
       canId = CAN0.getCanId();
-
-      Serial.print(F("RESP 0x"));
-      Serial.print(canId, HEX);
-      Serial.print(F(":"));
-      for (int i = 0; i < len; i++) {
-        Serial.print(' ');
-        if (buf[i] < 0x10) Serial.print('0');
-        Serial.print(buf[i], HEX);
-      }
-      Serial.println();
+      logFrame(canId, len, buf);
     } else {
       Serial.println(F("No response"));
     }
   } else {
     Serial.println(F("PID send failed"));
   }
+}
+
+void logFrame(unsigned long id, byte dlc, byte *data) {
+  Serial.print(F("ID: 0x"));
+  Serial.print(id, HEX);
+  Serial.print(F(" DLC:"));
+  Serial.print(dlc);
+  Serial.print(F(" Data:"));
+  for (int i = 0; i < dlc; i++) {
+    Serial.print(' ');
+    if (data[i] < 0x10) Serial.print('0');
+    Serial.print(data[i], HEX);
+  }
+  Serial.println();
+
+  unsigned long ts = millis();
+  logFile.print(ts);
+  logFile.print(',');
+  logFile.print(id, HEX);
+  logFile.print(',');
+  logFile.print(dlc);
+  logFile.print(',');
+  for (int i = 0; i < dlc; i++) {
+    if (i) logFile.print(' ');
+    if (data[i] < 0x10) logFile.print('0');
+    logFile.print(data[i], HEX);
+  }
+  logFile.println();
+  logFile.flush();
 }


### PR DESCRIPTION
## Summary
- log all CAN traffic and PID requests/responses to `canlog.csv` on the CAN-Bus Shield's microSD card
- rewrite README to focus on RedBoard setup, removing Python/iOGeek references

## Testing
- `arduino-cli version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a11023b86c832d839a78f85564df01