### PR TITLE
Add serial logger for CAN frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ timestamp_ms,id,dlc,data
 
 Each line contains the millisecond timestamp, CAN identifier, data length code, and hex data bytes.
 
+## PC Serial Logging
+The `serial_logger.py` script logs CAN frames sent over the Arduino's serial
+connection directly to your computer. By default it listens on `COM3` at
+115200 baud and appends frames to `CANLOG.CSV` in the repository. Run it with:
+
+```
+python serial_logger.py
+```
+
+When a frame contains a response to a known OBD-II PID, the script records the
+PID name (e.g. `ENGINE_RPM`) instead of the numeric identifier.
+
 ## DBC Generation
 The `build_dbc.py` helper analyzes a captured CAN log and produces a basic DBC file. The script groups frames by identifier and creates placeholder signals for each byte. When it detects responses to known OBD-II PIDs, it emits named signals with proper scaling and units.
 

--- a/serial_logger.py
+++ b/serial_logger.py
@@ -1,0 +1,54 @@
+import argparse
+import re
+import time
+from typing import Dict
+
+import serial
+
+PID_NAMES: Dict[int, str] = {
+    0x0C: "ENGINE_RPM",
+    0x0D: "VEHICLE_SPEED",
+    0x11: "THROTTLE_POSITION",
+    0x05: "COOLANT_TEMP",
+}
+
+PATTERN = re.compile(r"ID: 0x([0-9A-F]+)\s+DLC:(\d+)\s+Data:(.*)")
+
+
+def log_serial_frames(port: str, baudrate: int) -> None:
+    with serial.Serial(port, baudrate, timeout=1) as ser, open("CANLOG.CSV", "a") as log:
+        if log.tell() == 0:
+            log.write("timestamp_ms,id,dlc,data\n")
+        try:
+            while True:
+                line = ser.readline().decode("ascii", errors="ignore").strip()
+                match = PATTERN.match(line)
+                if not match:
+                    continue
+                can_id = match.group(1)
+                dlc = int(match.group(2))
+                data_str = match.group(3).strip()
+                data_bytes = [int(b, 16) for b in data_str.split() if b]
+
+                id_field = can_id
+                if data_bytes and data_bytes[0] == 0x41 and len(data_bytes) > 1:
+                    pid = data_bytes[1]
+                    if pid in PID_NAMES:
+                        id_field = PID_NAMES[pid]
+                ts_ms = int(time.time() * 1000)
+                log.write(f"{ts_ms},{id_field},{dlc},{' '.join(f'{b:02X}' for b in data_bytes)}\n")
+                log.flush()
+        except KeyboardInterrupt:
+            pass
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Log CAN frames from serial to CSV")
+    parser.add_argument("--port", default="COM3", help="Serial port, default COM3")
+    parser.add_argument("--baudrate", type=int, default=115200, help="Baud rate, default 115200")
+    args = parser.parse_args()
+    log_serial_frames(args.port, args.baudrate)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Python utility to log CAN frames from Arduino serial port into CANLOG.csv, substituting PID names when recognized
- document serial logging usage in README

## Testing
- `python -m py_compile serial_logger.py`


------
https://chatgpt.com/codex/tasks/task_e_68a224710a18832d8eba42205dc5ff48