### PR TITLE
Add door lock command mapping to DBC

### DIFF
--- a/build_dbc.py
+++ b/build_dbc.py
@@ -27,6 +27,8 @@ PID_SIGNALS: Dict[int, Tuple[str, int, float, float, str]] = {
 MESSAGE_NAMES: Dict[int, str] = {
     # Door unlock command observed during capture
     0x5F1: "DOOR_UNLOCK_CMD",
+    # Door lock command observed during capture
+    0x5FB: "DOOR_LOCK_CMD",
 }
 
 

--- a/output.dbc
+++ b/output.dbc
@@ -200,9 +200,28 @@ BO_ 1530 MSG_5FA: 6 Vector__XXX
  SG_ BYTE4 : 32|8@1+ (1,0) [0|255] "" Vector__XXX
  SG_ BYTE5 : 40|8@1+ (1,0) [0|255] "" Vector__XXX
 
-BO_ 1531 MSG_5FB: 3 Vector__XXX
- SG_ BYTE0 : 0|8@1+ (1,0) [0|255] "" Vector__XXX
+BO_ 1531 DOOR_LOCK_CMD: 3 Vector__XXX
+ SG_ LOCK_CMD : 0|8@1+ (1,0) [0|255] "" Vector__XXX
  SG_ BYTE1 : 8|8@1+ (1,0) [0|255] "" Vector__XXX
  SG_ BYTE2 : 16|8@1+ (1,0) [0|255] "" Vector__XXX
 
+BO_ 1533 MSG_5FD: 7 Vector__XXX
+ SG_ BYTE0 : 0|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ BYTE1 : 8|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ BYTE2 : 16|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ BYTE3 : 24|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ BYTE4 : 32|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ BYTE5 : 40|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ BYTE6 : 48|8@1+ (1,0) [0|255] "" Vector__XXX
+
+BO_ 1534 MSG_5FE: 4 Vector__XXX
+ SG_ BYTE0 : 0|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ BYTE1 : 8|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ BYTE2 : 16|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ BYTE3 : 24|8@1+ (1,0) [0|255] "" Vector__XXX
+
+BO_ 1984 MSG_7C0: 3 Vector__XXX
+ SG_ BYTE0 : 0|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ BYTE1 : 8|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ BYTE2 : 16|8@1+ (1,0) [0|255] "" Vector__XXX
 


### PR DESCRIPTION
## Summary
- Identify CAN ID 0x5FB as door lock command
- Map message to DOOR_LOCK_CMD and expose LOCK_CMD signal in DBC

## Testing
- `python parse_canlog.py`
- `python build_dbc.py CANLOG.CSV output.dbc`


------
https://chatgpt.com/codex/tasks/task_e_68a228a1a3a8832db5f4579b2d5834dd