### PR TITLE
Add neon console flair and document suspension commands

### DIFF
--- a/can_engine.py
+++ b/can_engine.py
@@ -71,6 +71,23 @@ MESSAGE_NAMES: Dict[int, str] = {
     0x5FB: "DOOR_LOCK_CMD",
 }
 
+# Neon-soaked console styling for that 1980's techno-thriller vibe
+NEON_MAGENTA = "\033[95m"
+NEON_CYAN = "\033[96m"
+NEON_GREEN = "\033[92m"
+RESET = "\033[0m"
+
+BANNER = f"""
+{NEON_MAGENTA}╔════════════════════════════════════════════╗
+║        CAN ENGINE :: TECHNO-THRILLER        ║
+╚════════════════════════════════════════════╝{RESET}
+"""
+
+
+def neon(text: str, color: str = NEON_CYAN) -> str:
+    """Wrap text in eye-searing ANSI colors."""
+    return f"{color}{text}{RESET}"
+
 
 # ---------------------------------------------------------------------------
 # CAN engine implementation
@@ -286,20 +303,24 @@ def main() -> None:
 
     args = parser.parse_args()
     engine = CANEngine()
+    print(BANNER)
 
     if args.cmd == "parse":
+        print(neon(">> INITIATING LOG PARSE SEQUENCE <<", NEON_MAGENTA))
         frames = engine.parse_log(args.log)
         for f in frames[:10]:
             decoded = engine.decode_obd_pid(f)
             if decoded:
-                print(f"ts {f.timestamp_ms} id 0x{f.can_id:03X}: {decoded}")
+                print(neon(f"[{f.timestamp_ms}] 0x{f.can_id:03X} :: {decoded}", NEON_GREEN))
     elif args.cmd == "builddbc":
+        print(neon(">> ASSEMBLING DBC MATRIX <<", NEON_MAGENTA))
         frames = engine.parse_log(args.log)
         engine.build_dbc(frames, args.output)
-        print(f"Wrote DBC to {args.output}")
+        print(neon(f"DBC WRITTEN TO {args.output}", NEON_GREEN))
     elif args.cmd == "serial":
         engine.log_serial_frames(args.port, args.baudrate)
     elif args.cmd == "send":
+        print(neon(">> TRANSMISSION COMMENCING <<", NEON_MAGENTA))
         engine.load_dbc(args.dbc)
         signal_values = {}
         for pair in args.signals:
@@ -308,6 +329,7 @@ def main() -> None:
             name, val = pair.split("=", 1)
             signal_values[name] = float(val)
         engine.send_command(args.message, args.channel, **signal_values)
+        print(neon(">> TRANSMISSION COMPLETE <<", NEON_GREEN))
     else:
         parser.print_help()
 

--- a/output.dbc
+++ b/output.dbc
@@ -192,10 +192,10 @@ BO_ 1529 MSG_5F9: 8 Vector__XXX
  SG_ BYTE6 : 48|8@1+ (1,0) [0|255] "" Vector__XXX
  SG_ BYTE7 : 56|8@1+ (1,0) [0|255] "" Vector__XXX
 
-BO_ 1530 MSG_5FA: 6 Vector__XXX
+BO_ 1530 SUSPENSION_STATUS: 6 Vector__XXX
  SG_ BYTE0 : 0|8@1+ (1,0) [0|255] "" Vector__XXX
  SG_ BYTE1 : 8|8@1+ (1,0) [0|255] "" Vector__XXX
- SG_ BYTE2 : 16|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ LEVEL : 16|8@1+ (1,0) [0|255] "" Vector__XXX
  SG_ BYTE3 : 24|8@1+ (1,0) [0|255] "" Vector__XXX
  SG_ BYTE4 : 32|8@1+ (1,0) [0|255] "" Vector__XXX
  SG_ BYTE5 : 40|8@1+ (1,0) [0|255] "" Vector__XXX
@@ -205,11 +205,11 @@ BO_ 1531 DOOR_LOCK_CMD: 3 Vector__XXX
  SG_ BYTE1 : 8|8@1+ (1,0) [0|255] "" Vector__XXX
  SG_ BYTE2 : 16|8@1+ (1,0) [0|255] "" Vector__XXX
 
-BO_ 1533 MSG_5FD: 7 Vector__XXX
+BO_ 1533 SUSPENSION_CMD: 7 Vector__XXX
  SG_ BYTE0 : 0|8@1+ (1,0) [0|255] "" Vector__XXX
  SG_ BYTE1 : 8|8@1+ (1,0) [0|255] "" Vector__XXX
  SG_ BYTE2 : 16|8@1+ (1,0) [0|255] "" Vector__XXX
- SG_ BYTE3 : 24|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ LEVEL : 24|8@1+ (1,0) [0|255] "" Vector__XXX
  SG_ BYTE4 : 32|8@1+ (1,0) [0|255] "" Vector__XXX
  SG_ BYTE5 : 40|8@1+ (1,0) [0|255] "" Vector__XXX
  SG_ BYTE6 : 48|8@1+ (1,0) [0|255] "" Vector__XXX
@@ -225,3 +225,5 @@ BO_ 1984 MSG_7C0: 3 Vector__XXX
  SG_ BYTE1 : 8|8@1+ (1,0) [0|255] "" Vector__XXX
  SG_ BYTE2 : 16|8@1+ (1,0) [0|255] "" Vector__XXX
 
+VAL_ 1533 LEVEL 81 "STANDARD" 82 "ACCESS" ;
+VAL_ 1530 LEVEL 162 "STANDARD" 166 "ACCESS" ;


### PR DESCRIPTION
## Summary
- Bathe console output in 1980's techno-thriller neon with banner and styled messages
- Name suspension command/status frames and add level signals in the DBC

## Testing
- `python can_engine.py parse CANLOG.CSV | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68a2306da74c832d889b70d7cc7bc9d5