### PR TITLE
feat: friendly python-can warning with flair

### DIFF
--- a/can_engine.py
+++ b/can_engine.py
@@ -289,7 +289,16 @@ class CANEngine:
     def interactive_menu(self, channel: str = "can0") -> None:
         """Interactive menu allowing the user to send PID requests."""
         if can is None:
-            raise RuntimeError("python-can is required to send PID requests")
+            msg = "\n".join(
+                [
+                    "╔════════════════════════════════════════════════════════════╗",
+                    "║  python-can module not detected!                          ║",
+                    "║  Install it with: pip install python-can                  ║",
+                    "╚════════════════════════════════════════════════════════════╝",
+                ]
+            )
+            print(neon(msg, NEON_MAGENTA))
+            return
         while True:
             print(neon("\nSelect PID to request:", NEON_MAGENTA))
             for idx, (pid, name) in enumerate(PID_NAMES.items(), start=1):


### PR DESCRIPTION
## Summary
- add stylish warning when python-can dependency is missing

## Testing
- `python can_engine.py menu`


------
https://chatgpt.com/codex/tasks/task_e_68a234fd5ea8832da7a6911d126097c4