### PR TITLE
feat: add retro console effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ All of the helper Python scripts have been consolidated into
 stream frames from a serial port and even transmit commands using a CAN
 interface.
 
+The console interface embraces a retro techno‑thriller aesthetic with
+ANSI neon coloring, ASCII art banners, progress bars and time‑stamped log
+lines to make every session feel like a scene from *WarGames*.
+
 Typical usage:
 
 ```bash


### PR DESCRIPTION
## Summary
- infuse CAN engine with retro techno-thriller console effects
- add reusable helpers for banners, progress bars, alerts and logs
- document the neon console aesthetic

## Testing
- `python can_engine.py --help`
- `python can_engine.py parse CANLOG.CSV`

------
https://chatgpt.com/codex/tasks/task_e_68a2362d3860832d9fda730c61e95a56