### PR TITLE
Add interactive menu when run without arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,6 @@ python can_engine.py send output.dbc DOOR_UNLOCK_CMD --channel can0
 
 The generated `output.dbc` can still be used with common CAN analysis
 tools for further exploration.
+
+Running `python can_engine.py` with no arguments now launches an
+interactive menu allowing you to choose from the above functions.


### PR DESCRIPTION
## Summary
- Present a main menu with key CAN utilities when `can_engine.py` runs without args
- Document the new no-argument menu in README

## Testing
- `python -m py_compile can_engine.py`
- `python can_engine.py <<'EOF'
0
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68a2385b4f58832dbd249b4cbbe78814