### PR TITLE
Fallback to virtual CAN interface on unsupported platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ python can_engine.py send output.dbc DOOR_UNLOCK_CMD --channel can0
 # omitting the message name will prompt for available messages and signals
 ```
 
+On platforms without native SocketCAN support (for example, Windows),
+the engine automatically falls back to python-can's virtual interface so
+commands can be encoded and tested without actual hardware.
+
 The generated `output.dbc` can still be used with common CAN analysis
 tools for further exploration.
 

--- a/can_engine.py
+++ b/can_engine.py
@@ -20,6 +20,7 @@ import argparse
 import csv
 import threading
 import time
+import socket
 from dataclasses import dataclass
 from typing import Optional
 
@@ -352,8 +353,9 @@ class CANEngine:
 
         msg = self.db.get_message_by_name(message)
         data = msg.encode(signals)
+        interface = "socketcan" if hasattr(socket, "CMSG_SPACE") else "virtual"
         try:
-            bus = can.interface.Bus(channel=channel, interface="socketcan")
+            bus = can.interface.Bus(channel=channel, interface=interface)
         except (OSError, NotImplementedError) as exc:
             system_alert(f"Failed to access CAN interface '{channel}': {exc}")
             return False
@@ -399,8 +401,9 @@ class CANEngine:
         if can is None:
             raise RuntimeError("python-can is required to send PID requests")
         data = bytes([0x02, 0x01, pid, 0x00, 0x00, 0x00, 0x00, 0x00])
+        interface = "socketcan" if hasattr(socket, "CMSG_SPACE") else "virtual"
         try:
-            bus = can.interface.Bus(channel=channel, interface="socketcan")
+            bus = can.interface.Bus(channel=channel, interface=interface)
         except (OSError, NotImplementedError) as exc:
             system_alert(f"Failed to access CAN interface '{channel}': {exc}")
             return False


### PR DESCRIPTION
## Summary
- Import socket and detect platform support for `socketcan`
- Fall back to python-can's virtual bus when `socket.CMSG_SPACE` is unavailable
- Document the automatic virtual interface fallback in the README

## Testing
- `python -m py_compile can_engine.py`
- `python can_engine.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68a244e19250832dbe309571b05871c0