### PR TITLE
Prepopulate DBC command bytes from CAN logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ console flair:
 3. **Interactive PID console** – issue OBD‑II PID requests from a menu and
    display decoded responses.
 
+When sending a message interactively, the helper now inspects `CANLOG.CSV`
+and prepopulates each signal with the most recently observed byte values so
+common commands can be re‑issued quickly.
+
 Example invocations:
 
 ```bash


### PR DESCRIPTION
## Summary
- Add helper to load last-seen CAN signal values from CANLOG.CSV
- Pre-fill interactive DBC command prompts with observed byte values
- Document auto-population of signals in README

## Testing
- `python -m py_compile can_engine.py`
- `python - <<'PY'
from can_engine import CANb0t
bot = CANb0t()
bot.load_dbc('landrover2008lr3.dbc')
defs = bot._load_recent_values()
print('DOOR_UNLOCK_CMD', defs.get('DOOR_UNLOCK_CMD'))
print('DOOR_LOCK_CMD', defs.get('DOOR_LOCK_CMD'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a512cb08c8832d9fa255f66c84d2b6