### PR TITLE
Handle CAN interface deprecation and shutdown bus cleanly

### DIFF
--- a/canrx_tool.py
+++ b/canrx_tool.py
@@ -562,22 +562,27 @@ def pid_console(cfg: Config) -> None:
         return
     input("Press Enter to send requests...")
     try:
-        bus = can.interface.Bus(channel=cfg.channel, bustype="socketcan")
+        bus = can.interface.Bus(channel=cfg.channel, interface="socketcan")
     except Exception:
         try:
-            bus = can.interface.Bus(bustype="virtual")
+            bus = can.interface.Bus(interface="virtual")
         except Exception:
             print("Unable to open CAN bus")
             return
 
     pids = [0x0C, 0x0D, 0x11, 0x05]
-    for pid in pids:
-        msg = can.Message(arbitration_id=0x7DF, data=[0x02, 0x01, pid, 0, 0, 0, 0, 0])
-        try:
-            bus.send(msg)
-            print(f"Requested PID 0x{pid:02X}")
-        except Exception:
-            pass
+    try:
+        for pid in pids:
+            msg = can.Message(
+                arbitration_id=0x7DF, data=[0x02, 0x01, pid, 0, 0, 0, 0, 0]
+            )
+            try:
+                bus.send(msg)
+                print(f"Requested PID 0x{pid:02X}")
+            except Exception:
+                pass
+    finally:
+        bus.shutdown()
     print("Done. Returning to menu.")
 
 


### PR DESCRIPTION
## Summary
- Replace deprecated `bustype` argument with `interface` when creating the CAN bus
- Ensure PID demo shuts down the bus to avoid `VirtualBus was not properly shut down`

## Testing
- `python -m py_compile canrx_tool.py`
- `python - <<'PY'
from canrx_tool import pid_console, Config
import builtins
builtins.input = lambda *args, **kwargs: ''

cfg = Config()

pid_console(cfg)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a52df53730832da3cf6b72b022b197